### PR TITLE
Implements a global plugin config for filtering out issues by status

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jiraext/Config.java
+++ b/src/main/java/org/jenkinsci/plugins/jiraext/Config.java
@@ -63,6 +63,8 @@ public class Config
         private String username;
         private String password;
         private String pattern;
+        private String includeStatuses;
+        private String excludeStatuses;
         private boolean verboseLogging;
         private Integer timeout;
 
@@ -127,6 +129,24 @@ public class Config
             this.pattern = pattern;
         }
 
+        public String getIncludeStatuses() {
+            return includeStatuses;
+        }
+
+        public void setIncludeStatuses(String statusList)
+        {
+            this.includeStatuses = statusList;
+        }
+
+        public String getExcludeStatuses() {
+            return excludeStatuses;
+        }
+
+        public void setExcludeStatuses(String statusList)
+        {
+            this.excludeStatuses = statusList;
+        }
+
         public void setVerboseLogging(boolean verboseLogging)
         {
             this.verboseLogging = verboseLogging;
@@ -153,6 +173,8 @@ public class Config
             setUsername(formData.getString("username"));
             setPassword(formData.getString("password"));
             setPattern(formData.getString("pattern"));
+            setIncludeStatuses(formData.getString("includeStatuses"));
+            setExcludeStatuses(formData.getString("excludeStatuses"));
             setVerboseLogging(formData.getBoolean("verboseLogging"));
             setTimeout(formData.getInt("timeout"));
             save();

--- a/src/main/resources/org/jenkinsci/plugins/jiraext/Config/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/jiraext/Config/global.jelly
@@ -19,6 +19,14 @@
                  description="Comma-separate string of jira prefixes">
             <f:textbox default="FOO-,BAR-" />
         </f:entry>
+        <f:entry title="Include Status" field="includeStatuses"
+                 description="Comma-separate string of jira issue status's to filter on">
+            <f:textbox default="" />
+        </f:entry>
+        <f:entry title="Exclude Status" field="excludeStatuses"
+                 description="Comma-separate string of jira issue status's to filter out">
+            <f:textbox default="" />
+        </f:entry>
         <f:entry title="Verbose Logging" field="verboseLogging"
                  description="Whether to log a lot of information, ie API http debugging, in jobs">
             <f:checkbox />


### PR DESCRIPTION
It may be desired to not update an issue if it has (or doesn’t have) a specific status.

This commit adds a global plugin configuration where statuses to include or exclude can be defined.

Before updating an issue, it’s status will be checked, and it may be skipped.

I attempted to find a good central point at which to do this check, and it seems like the `JiraClientSvcImpl` class was the best fit. Very open to suggestions though.

<img width="627" alt="screen shot 2017-03-02 at 3 21 18 pm" src="https://cloud.githubusercontent.com/assets/848767/23490225/fb94d952-ff5b-11e6-9d7a-16409e925e9d.png">
