### PR TITLE
[Fixed JENKINS-35339] support Conditional Buildstep

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jiraext/view/JiraExtBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/jiraext/view/JiraExtBuildStep.java
@@ -22,10 +22,8 @@ import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.Util;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
-import hudson.model.Descriptor;
-import hudson.model.Saveable;
+import hudson.model.*;
+import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.DescribableList;
 import jenkins.model.Jenkins;
@@ -75,7 +73,7 @@ public class JiraExtBuildStep
 
     @Extension
     public static class DescriptorImpl
-        extends Descriptor<Builder>{
+        extends BuildStepDescriptor<Builder> {
 
         @Override
         public String getDisplayName()
@@ -91,6 +89,12 @@ public class JiraExtBuildStep
         public List<JiraOperationExtensionDescriptor> getExtensionDescriptors()
         {
             return JiraOperationExtensionDescriptor.all();
+        }
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+            // This builder can be used with all kinds of project types
+            return true;
         }
     }
 }


### PR DESCRIPTION
see https://wiki.jenkins-ci.org/display/JENKINS/Conditional+BuildStep+Plugin
> Missing builder
If you're not able to add the builder of your choice within a conditional build step (because it's not available within the dropdown), then this is likely because the builder does not provide a @DataBoundConstructor constructor and/or the Descriptor does not extend hudson.tasks.BuildStepDescriptor. For non programmers: the plugin you would like to use does not yet follow the newest Jenkins coding guidelines. Without this, the conditional buildstep plugin is not able to work with it.

<img width="918" alt="screenshot at jun 15 06-20-15" src="https://user-images.githubusercontent.com/555134/27183361-3846d0b0-5193-11e7-8fed-4e1a98884cc6.png">
