### PR TITLE
Fix MentionedInCommitStrategy for tickets in multiple lines

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jiraext/view/MentionedInCommitStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/jiraext/view/MentionedInCommitStrategy.java
@@ -106,24 +106,24 @@ public class MentionedInCommitStrategy
                 final String regex = "\\A[0-9]*";
                 final Pattern pattern = Pattern.compile(regex);
                 final Matcher matcher = pattern.matcher(firstOccurrence);
-                 
-                if( !matcher.find() )
-+               {
-+                  break;
-+               }
-+                /**
-+                 * It is totally unclear why a regex for the entire 
-+                 * Jira ticket identifier is not a configuration item
-+                 * It is strange to be seperating the ticket number from the 
-+                 * prefix, just to put it back together again - 
-+                 * without using either seperately.  
-+                 *
-+                 * This would be a trivial change to the config, and 
-+                 * #probably# not break any existing code other than these isolated 
-+                 * areas where the prefix is being searched.
-+                 */
 
-+               final String ticketNumber = matcher.group();
+                if (!matcher.find())
+                {
+                    break;
+                }
+                /**
+                 * It is totally unclear why a regex for the entire
+                 * Jira ticket identifier is not a configuration item
+                 * It is strange to be seperating the ticket number from the
+                 * prefix, just to put it back together again -
+                 * without using either seperately.
+                 *
+                 * This would be a trivial change to the config, and
+                 * #probably# not break any existing code other than these isolated
+                 * areas where the prefix is being searched.
+                 */
+
+                final String ticketNumber = matcher.group();
 
                 if (StringUtils.isEmpty(ticketNumber))
                 {

--- a/src/main/java/org/jenkinsci/plugins/jiraext/view/MentionedInCommitStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/jiraext/view/MentionedInCommitStrategy.java
@@ -103,12 +103,27 @@ public class MentionedInCommitStrategy
                 }
 
                 final String firstOccurrence = msg.substring(foundPos + validJiraPrefix.length());
-                final String regex = "^([0-9]*).*$";
+                final String regex = "\\A[0-9]*";
                 final Pattern pattern = Pattern.compile(regex);
                 final Matcher matcher = pattern.matcher(firstOccurrence);
-                matcher.matches();
+                 
+                if( !matcher.find() )
++               {
++                  break;
++               }
++                /**
++                 * It is totally unclear why a regex for the entire 
++                 * Jira ticket identifier is not a configuration item
++                 * It is strange to be seperating the ticket number from the 
++                 * prefix, just to put it back together again - 
++                 * without using either seperately.  
++                 *
++                 * This would be a trivial change to the config, and 
++                 * #probably# not break any existing code other than these isolated 
++                 * areas where the prefix is being searched.
++                 */
 
-                final String ticketNumber = matcher.group(1);
++               final String ticketNumber = matcher.group();
 
                 if (StringUtils.isEmpty(ticketNumber))
                 {

--- a/src/test/java/org/jenkinsci/plugins/jiraext/view/MentionedInCommitStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jiraext/view/MentionedInCommitStrategyTest.java
@@ -97,7 +97,7 @@ public class MentionedInCommitStrategyTest
     @Test
     public void testMultipleTicketNames()
     {
-        ChangeLogSet.Entry entry = MockChangeLogUtil.mockChangeLogSetEntry("FOO-101 and BAR-101 are both in the message");
+        ChangeLogSet.Entry entry = MockChangeLogUtil.mockChangeLogSetEntry("FOO-101 and\n BAR-101 are both in the message");
         assertThat(strategy.getJiraIssuesFromChangeSet(entry).size(), equalTo(2));
         assertThat(strategy.getJiraIssuesFromChangeSet(entry),
                 hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("FOO-101"))));


### PR DESCRIPTION
I found out that the MentionedIncommitStrategy failed to match tickets in multiple lines of a single commit.
This is fixed in another pr: https://github.com/jenkinsci/jira-ext-plugin/pull/5
So I'm fixing the compilation errors and modified the unit test for this case.