### PR TITLE
Modify MentionedInCommitStrategy to use the comment of the change

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jiraext/view/MentionedInCommitStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/jiraext/view/MentionedInCommitStrategy.java
@@ -23,6 +23,7 @@ import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 
+import hudson.plugins.git.GitChangeSet;
 import hudson.scm.ChangeLogSet;
 
 import org.apache.commons.lang.StringUtils;
@@ -92,6 +93,10 @@ public class MentionedInCommitStrategy
         for (String validJiraPrefix : Config.getGlobalConfig().getJiraTickets())
         {
             String msg = change.getMsg();
+            if (change instanceof GitChangeSet)
+            {
+              msg = ((GitChangeSet) change).getComment();
+            }
 
             while (StringUtils.isNotEmpty(msg))
             {


### PR DESCRIPTION
Add logic to get comment from change. getMsg will only return the first line of git commit.

See JENKINS-49143