### PR TITLE
square brackets and colons as first word in commit delimiters

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jiraext/view/FirstWordOfCommitStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/jiraext/view/FirstWordOfCommitStrategy.java
@@ -69,10 +69,20 @@ public class FirstWordOfCommitStrategy
         String msg = change.getMsg();
         String firstWordOfTicket;
         firstWordOfTicket = msg.substring(0, (msg.contains(" ") ? StringUtils.indexOf(msg, " ") : msg.length()));
+        firstWordOfTicket = firstWordOfTicket.substring(0, (firstWordOfTicket.contains("]") ? StringUtils.indexOf(firstWordOfTicket, "]") : firstWordOfTicket.length()));
+        firstWordOfTicket = firstWordOfTicket.substring(0, (firstWordOfTicket.contains(":") ? StringUtils.indexOf(firstWordOfTicket, ":") : firstWordOfTicket.length()));
 
         for (String validJiraPrefix : Config.getGlobalConfig().getJiraTickets())
         {
             if (firstWordOfTicket.endsWith(":"))
+            {
+                firstWordOfTicket = firstWordOfTicket.substring(0, firstWordOfTicket.length() - 1);
+            }
+            if (firstWordOfTicket.startsWith("["))
+            {
+                firstWordOfTicket = firstWordOfTicket.substring(1);
+            }
+            if (firstWordOfTicket.endsWith("]"))
             {
                 firstWordOfTicket = firstWordOfTicket.substring(0, firstWordOfTicket.length() - 1);
             }

--- a/src/test/java/org/jenkinsci/plugins/jiraext/view/FirstWordOfCommitStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jiraext/view/FirstWordOfCommitStrategyTest.java
@@ -79,14 +79,22 @@ public class FirstWordOfCommitStrategyTest
         ChangeLogSet mockChangeSet = MockChangeLogUtil.mockChangeLogSet(
                 new MockChangeLogUtil.MockChangeLog("FOO-101 first", "dalvizu"),
                 new MockChangeLogUtil.MockChangeLog("BAR-102 again", "jsmith"),
+                new MockChangeLogUtil.MockChangeLog("BAR-103: third", "jsmith"),
+                new MockChangeLogUtil.MockChangeLog("[BAR-104] fourth", "jsmith"),
+                new MockChangeLogUtil.MockChangeLog("[BAR-105][section] fifth", "jsmith"),
+                new MockChangeLogUtil.MockChangeLog("[BAR-106]: sixth", "jsmith"),
                 new MockChangeLogUtil.MockChangeLog("No Valid Ticket", "build robot"));
         AbstractBuild mockBuild = mock(AbstractBuild.class);
         when(mockBuild.getChangeSet()).thenReturn(mockChangeSet);
         List<JiraCommit> commits = strategy.getJiraCommits(mockBuild,
                 new StreamBuildListener(System.out, Charset.defaultCharset()));
-        assertEquals(commits.size(), 2);
+        assertEquals(commits.size(), 6);
 
         assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("FOO-101"))));
         assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("BAR-102"))));
+        assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("BAR-103"))));
+        assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("BAR-104"))));
+        assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("BAR-105"))));
+        assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("BAR-106"))));
     }
 }


### PR DESCRIPTION
Accommodate messages that begin with:

```
[BAR-104] fourth
[BAR-105][section] fifth
[BAR-106]: sixth
```