### PR TITLE
accommodate non-standard jira project keys

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jiraext/view/FirstWordOfCommitStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/jiraext/view/FirstWordOfCommitStrategy.java
@@ -72,7 +72,7 @@ public class FirstWordOfCommitStrategy
         String firstWordOfTicket;
         firstWordOfTicket = msg.substring(0, (msg.contains(" ") ? StringUtils.indexOf(msg, " ") : msg.length()));
 
-        final String regex = "([0-9A-Z]+-)([0-9]+)";
+        final String regex = "([A-Z][0-9A-Z_]+-)([0-9]+)";
         final Pattern pattern = Pattern.compile(regex);
         final Matcher matcher = pattern.matcher(firstWordOfTicket);
 

--- a/src/test/java/org/jenkinsci/plugins/jiraext/view/FirstWordOfCommitStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jiraext/view/FirstWordOfCommitStrategyTest.java
@@ -52,7 +52,7 @@ public class FirstWordOfCommitStrategyTest
     @Before
     public void setUp()
     {
-        Config.getGlobalConfig().setPattern("FOO-,BAR-");
+        Config.getGlobalConfig().setPattern("FOO-,BAR-,MY_EXAMPLE_PROJECT-");
     }
 
     @Test
@@ -83,6 +83,7 @@ public class FirstWordOfCommitStrategyTest
                 new MockChangeLogUtil.MockChangeLog("[BAR-104] fourth", "jsmith"),
                 new MockChangeLogUtil.MockChangeLog("[BAR-105][section] fifth", "jsmith"),
                 new MockChangeLogUtil.MockChangeLog("[BAR-106]: sixth", "jsmith"),
+                new MockChangeLogUtil.MockChangeLog("MY_EXAMPLE_PROJECT-107 seventh", "jsmith"),
                 new MockChangeLogUtil.MockChangeLog("No Valid Ticket", "build robot"));
         AbstractBuild mockBuild = mock(AbstractBuild.class);
         when(mockBuild.getChangeSet()).thenReturn(mockChangeSet);
@@ -96,5 +97,6 @@ public class FirstWordOfCommitStrategyTest
         assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("BAR-104"))));
         assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("BAR-105"))));
         assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("BAR-106"))));
+        assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("MY_EXAMPLE_PROJECT-107"))));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/jiraext/view/FirstWordOfCommitStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jiraext/view/FirstWordOfCommitStrategyTest.java
@@ -84,6 +84,7 @@ public class FirstWordOfCommitStrategyTest
                 new MockChangeLogUtil.MockChangeLog("[BAR-105][section] fifth", "jsmith"),
                 new MockChangeLogUtil.MockChangeLog("[BAR-106]: sixth", "jsmith"),
                 new MockChangeLogUtil.MockChangeLog("MY_EXAMPLE_PROJECT-107 seventh", "jsmith"),
+                new MockChangeLogUtil.MockChangeLog("2013PROJECT-108 eighth", "jsmith"),
                 new MockChangeLogUtil.MockChangeLog("No Valid Ticket", "build robot"));
         AbstractBuild mockBuild = mock(AbstractBuild.class);
         when(mockBuild.getChangeSet()).thenReturn(mockChangeSet);
@@ -98,6 +99,6 @@ public class FirstWordOfCommitStrategyTest
         assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("BAR-105"))));
         assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("BAR-106"))));
         assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("MY_EXAMPLE_PROJECT-107"))));
-        assertThat(commits, is(not(hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("2013PROJECT-107"))))));
+        assertThat(commits, is(not(hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("2013PROJECT-108"))))));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/jiraext/view/FirstWordOfCommitStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jiraext/view/FirstWordOfCommitStrategyTest.java
@@ -52,7 +52,7 @@ public class FirstWordOfCommitStrategyTest
     @Before
     public void setUp()
     {
-        Config.getGlobalConfig().setPattern("FOO-,BAR-,MY_EXAMPLE_PROJECT-");
+        Config.getGlobalConfig().setPattern("FOO-,BAR-,MY_EXAMPLE_PROJECT-,2013PROJECT-");
     }
 
     @Test
@@ -89,7 +89,7 @@ public class FirstWordOfCommitStrategyTest
         when(mockBuild.getChangeSet()).thenReturn(mockChangeSet);
         List<JiraCommit> commits = strategy.getJiraCommits(mockBuild,
                 new StreamBuildListener(System.out, Charset.defaultCharset()));
-        assertEquals(commits.size(), 6);
+        assertEquals(commits.size(), 7);
 
         assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("FOO-101"))));
         assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("BAR-102"))));
@@ -98,5 +98,6 @@ public class FirstWordOfCommitStrategyTest
         assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("BAR-105"))));
         assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("BAR-106"))));
         assertThat(commits, hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("MY_EXAMPLE_PROJECT-107"))));
+        assertThat(commits, is(not(hasItem(Matchers.<JiraCommit>hasProperty("jiraTicket", equalTo("2013PROJECT-107"))))));
     }
 }


### PR DESCRIPTION
the default project key format consists of only letters; however, according to
https://confluence.atlassian.com/adminjiraserver071/changing-the-project-key-format-802592378.html
, the project key may also include an underscore

(accommodate an edge case, just in case)