### PR TITLE
Resolved mismatch stubbings in AddLabelToFieldTest.java

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/jiraext/view/AddLabelToFieldTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jiraext/view/AddLabelToFieldTest.java
@@ -116,6 +116,7 @@ public class AddLabelToFieldTest {
         jiraCommits.add(new JiraCommit("SSD-102", MockChangeLogUtil.mockChangeLogSetEntry("Test Comment")));
         doThrow(new RuntimeException("Issue is invalid"))
                 .when(jiraClientSvc).addLabelToField(eq("SSD-101"), eq("CustomField_123"), eq("Completed"));
+        doNothing().when(jiraClientSvc).addLabelToField("SSD-102", "CustomField_123", "Completed");
         addLabelToField.perform(jiraCommits, mockBuild, mock(Launcher.class), new StreamBuildListener(System.out, Charset.defaultCharset()));
         verify(jiraClientSvc, times(1)).addLabelToField(eq("SSD-101"), eq("CustomField_123"), eq("Completed"));
         verify(jiraClientSvc, times(1)).addLabelToField(eq("SSD-102"), eq("CustomField_123"), eq("Completed"));


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In the test `testResiliency`: 
* the `addLabelToField` method for the `jiraClientSvc` object:
i) during test execution the method is actually called with arguments `["SSD-102", "CustomField_123", "Completed"]`, but is not stubbed, resulting in a mismatch stubbing. 

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira (Not Applicable)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes (Not Applicable)
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed (Not Applicable)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
