### PR TITLE
Resolved mismatch stubbings in TransitionTest.java

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/jiraext/view/TransitionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jiraext/view/TransitionTest.java
@@ -101,7 +101,8 @@ public class TransitionTest
         jiraCommits.add(new JiraCommit("SSD-101", MockChangeLogUtil.mockChangeLogSetEntry("Test Comment")));
         jiraCommits.add(new JiraCommit("SSD-102", MockChangeLogUtil.mockChangeLogSetEntry("Test Comment")));
         doThrow(new RuntimeException("Issue is invalid"))
-                .when(jiraClientSvc).changeWorkflowOfTicket("SSD-101", "Test Comment");
+                .when(jiraClientSvc).changeWorkflowOfTicket("SSD-101", "Resolve");
+        doNothing().when(jiraClientSvc).changeWorkflowOfTicket("SSD-102", "Resolve");
         transition.perform(jiraCommits, mockBuild, mock(Launcher.class), new StreamBuildListener(System.out, Charset.defaultCharset()));
         verify(jiraClientSvc, times(1)).changeWorkflowOfTicket(eq("SSD-101"), eq("Resolve"));
         verify(jiraClientSvc, times(1)).changeWorkflowOfTicket(eq("SSD-102"), eq("Resolve"));


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In the test `testResiliency`:

* The `changeWorkflowOfTicket` method for the `jiraClientSvc` object:
i) is stubbed with arguments `["SSD-101", "Test Comment"]`
ii) during test execution the method is actually called with arguments `["SSD-101", "Resolve"]`, resulting in a mismatch stubbing
iii) during test execution the method is actually called with arguments `["SSD-102", "Resolve"]`, but is not stubbed, resulting in another mismatch stubbing

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira (Not Applicable)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes (Not Applicable)
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed (Not Applicable)
<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
